### PR TITLE
Fix wiki link to LR parser

### DIFF
--- a/site/docs/guide/index.md
+++ b/site/docs/guide/index.md
@@ -80,7 +80,7 @@ conflicts. More about that in a moment.
 
 When writing grammars for LR-based tools, it can help to have a rough
 feel for this algorithm. The
-[Wikipedia](https://en.wikipedia.org/wiki/Abstract_interpretation)
+[Wikipedia](https://en.wikipedia.org/wiki/LR_parser)
 article linked above is a good introduction. For a more in-depth
 treatment, I recommend Chapter 9 of [this
 book](https://dickgrune.com/Books/PTAPG_1st_Edition/BookBody.pdf)


### PR DESCRIPTION
Seems that the link was the wrong one of the two above - the "LR parser" article is the one that explains something about the LR parsing algorithm, "Abstract interpretation" is rather abstract